### PR TITLE
Add PHP's XSL library

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,4 +17,5 @@ RUN apt-get install -y fontconfig
 RUN pecl install xdebug
 RUN echo 'zend_extension=/usr/local/lib/php/extensions/no-debug-non-zts-20160303/xdebug.so' > /usr/local/etc/php/conf.d/xdebug.ini
 
-RUN docker-php-ext-install bcmath 
+RUN apt-get install -y libxslt-dev
+RUN docker-php-ext-install bcmath xsl


### PR DESCRIPTION
Here is the output that verifies it's installation:

```
[juampy@carboncete /var/www/draco/drupal_tests (master)]$ docker -vvv build -t draco .
Sending build context to Docker daemon  101.4kB
Step 1/13 : FROM drupal:latest
 ---> 5a8e333cfedd
Step 2/13 : RUN apt-get update
 ---> Using cache
 ---> db7ecb19607b
Step 3/13 : RUN apt-get install -y bzip2
 ---> Using cache
 ---> e98c2b8e3a1b
Step 4/13 : RUN cd '/opt' && curl -L https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-2.1.1-linux-x86_64.tar.bz2 | tar xjvf -
 ---> Using cache
 ---> 95ee3d92799e
Step 5/13 : RUN ln -s /opt/phantomjs-2.1.1-linux-x86_64/bin/phantomjs /usr/local/bin
 ---> Using cache
 ---> 680d24fe59cb
Step 6/13 : RUN apt-get install -y sudo
 ---> Using cache
 ---> be92eb273325
Step 7/13 : RUN apt-get install -y sqlite3
 ---> Using cache
 ---> bad2e447a199
Step 8/13 : RUN apt-get install -y vim
 ---> Using cache
 ---> 2c334261a10a
Step 9/13 : RUN apt-get install -y fontconfig
 ---> Using cache
 ---> 4bb5fd6f1b13
Step 10/13 : RUN pecl install xdebug
 ---> Using cache
 ---> 99511d45cb8e
Step 11/13 : RUN echo 'zend_extension=/usr/local/lib/php/extensions/no-debug-non-zts-20160303/xdebug.so' > /usr/local/etc/php/conf.d/xdebug.ini
 ---> Using cache
 ---> ecdcec8ffd9b
Step 12/13 : RUN apt-get install -y libxslt-dev
 ---> Using cache
 ---> 96e2869dd557
Step 13/13 : RUN docker-php-ext-install bcmath xsl
 ---> Using cache
 ---> 3efafd1fa9fb
Successfully built 3efafd1fa9fb
Successfully tagged draco:latest
[juampy@carboncete /var/www/draco/drupal_tests (master)]$ docker run -it draco bash
root@05258c428602:/var/www/html# php -i | grep xsl
/usr/local/etc/php/conf.d/docker-php-ext-xsl.ini,
xsl
libxslt Version => 1.1.28
libxslt compiled against libxml Version => 2.9.1
libexslt Version => 1.1.28
```