### PR TITLE
Automatic setup of new repositories

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,9 +9,8 @@ jobs:
       - run:
           name: Install test dependencies
           command: |
-            apt update && apt install git curl perl -y
-            curl -o /usr/local/bin/circleci https://circle-downloads.s3.amazonaws.com/releases/build_agent_wrapper/circleci && chmod +x /usr/local/bin/circleci
-            ./install-composer.sh
+            sudo curl -o /usr/local/bin/circleci https://circle-downloads.s3.amazonaws.com/releases/build_agent_wrapper/circleci && sudo chmod +x /usr/local/bin/circleci
+            sudo ./install-composer.sh
 
       - run:
           name: Run tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: debian:stretch
+      - image: indiehosters/git:latest
     steps:
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,9 +7,9 @@ jobs:
       - checkout
 
       - run:
-          name: Install git
+          name: Install test dependencies
           command: |
-            apt update && apt install git -y
+            apt update && apt install git curl perl -y
 
       - run:
           name: Run tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,4 +22,4 @@ jobs:
             mv test_this_branch test_last_tag artifacts
 
       - store_artifacts:
-          path: ~/artifacts
+          path: artifacts

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,6 +6,8 @@ jobs:
     steps:
       - checkout
 
+      - setup_remote_docker
+
       - run:
           name: Run tests
           command: ./test.sh $CIRCLE_BRANCH
@@ -14,7 +16,7 @@ jobs:
           name: Move artifacts
           command: |
             mkdir artifacts
-            mv test_this_branch test_last_tag artifacts
+            mv test_this_branch test_last_tag fb_instant_articles artifacts
 
       - store_artifacts:
           path: artifacts

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,8 +6,6 @@ jobs:
     steps:
       - checkout
 
-      - setup_remote_docker
-
       - run:
           name: Run tests
           command: ./test.sh $CIRCLE_BRANCH
@@ -16,7 +14,7 @@ jobs:
           name: Move artifacts
           command: |
             mkdir artifacts
-            mv test_this_branch test_last_tag fb_instant_articles artifacts
+            mv test_this_branch test_last_tag artifacts
 
       - store_artifacts:
           path: artifacts

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,6 +10,8 @@ jobs:
           name: Install test dependencies
           command: |
             apt update && apt install git curl perl -y
+            curl -o /usr/local/bin/circleci https://circle-downloads.s3.amazonaws.com/releases/build_agent_wrapper/circleci && chmod +x /usr/local/bin/circleci
+            ./install-composer.sh
 
       - run:
           name: Run tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,12 +7,6 @@ jobs:
       - checkout
 
       - run:
-          name: Install test dependencies
-          command: |
-            sudo curl -o /usr/local/bin/circleci https://circle-downloads.s3.amazonaws.com/releases/build_agent_wrapper/circleci && sudo chmod +x /usr/local/bin/circleci
-            sudo ./install-composer.sh
-
-      - run:
           name: Run tests
           command: ./test.sh $CIRCLE_BRANCH
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,3 +8,12 @@ jobs:
       - run:
           name: Run tests
           command: ./test.sh $CIRCLE_BRANCH
+
+      - run:
+          name: Move artifacts
+          command: |
+            mkdir artifacts
+            mv test_this_branch test_last_tag artifacts
+
+    - store_artifacts:
+        path: ~/artifacts

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,5 +15,5 @@ jobs:
             mkdir artifacts
             mv test_this_branch test_last_tag artifacts
 
-    - store_artifacts:
-        path: ~/artifacts
+      - store_artifacts:
+          path: ~/artifacts

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: debian:stretch
+      - image: circleci/php:7.1-cli
     steps:
       - checkout
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,6 +5,12 @@ jobs:
       - image: debian:stretch
     steps:
       - checkout
+
+      - run:
+          name: Install git
+          command: |
+            apt update && apt install git -y
+
       - run:
           name: Run tests
           command: ./test.sh $CIRCLE_BRANCH

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: indiehosters/git:latest
+      - image: debian:stretch
     steps:
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,10 @@
+version: 2
+jobs:
+  build:
+    docker:
+      - image: debian:stretch
+    steps:
+      - checkout
+      - run:
+          name: Run tests
+          command: ./test.sh $CIRCLE_BRANCH

--- a/README.md
+++ b/README.md
@@ -21,9 +21,15 @@ If you want to test a whole Drupal site, and not an individual module, see
 
 ## Getting started with CircleCI
 
-1. Copy the `templates/circleci-2.0` directory to your module repository as
-  `.circleci`.
-1. Follow the steps at the top of the file.
+1. `cd` to the directory with your Drupal module. Make sure it's a git
+   repository first!
+1. `curl https://github.com/deviantintegral/drupal_tests/raw/master/setup.sh | bash`
+1. Review and commit the new files.
+1. Connect the repository to CircleCI.
+1. Add a `COMPOSER_AUTH` environment variable to Circle if you are using
+   private repositories.
+1. Push a branch . At this point, all jobs should run, though no tests are
+   actually being executed.
 1. To override a given hook, copy it to your `.circleci` directory. Then, in
    the run step, copy the script to the root of the project. For example, if
    you need to override `hooks/code-sniffer.sh`, the `run` step for the
@@ -35,8 +41,6 @@ If you want to test a whole Drupal site, and not an individual module, see
        cp ./modules/$CIRCLE_PROJECT_REPONAME/.circleci/code-sniffer.sh /var/www/html
        ./code-sniffer.sh $CIRCLE_PROJECT_REPONAME
     ```
-1. Connect your repository to Circle. At this point, all jobs should run,
-   though no tests are actually being executed.
 
 ## Getting started with tests
 

--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ If you want to test a whole Drupal site, and not an individual module, see
 
 ## Getting started with tests
 
+If you ran `setup.sh` these steps have been done automatically.
+
 1. Copy all of the files and directories from `templates/module` to the root of
    your new module.
 1. Edit `phpunit.core.xml.dist` and set the whitelist paths for coverage

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ If you want to test a whole Drupal site, and not an individual module, see
 
 1. `cd` to the directory with your Drupal module. Make sure it's a git
    repository first!
-1. `curl https://github.com/deviantintegral/drupal_tests/raw/master/setup.sh | bash`
+1. `curl -L https://github.com/deviantintegral/drupal_tests/raw/master/setup.sh | bash`
 1. Review and commit the new files.
 1. Connect the repository to CircleCI.
 1. Add a `COMPOSER_AUTH` environment variable to Circle if you are using

--- a/setup.sh
+++ b/setup.sh
@@ -33,11 +33,11 @@ perl -i -pe "s/my_module/$MODULE/g" phpunit.core.xml.dist
 
 # Download and set up the Behat testing configuration.
 mkdir -p "tests/src/Behat/features/bootstrap"
-
 curl -s -L -q https://github.com/deviantintegral/drupal_tests/raw/$TAG/templates/module/tests/src/Behat/behat.yml > tests/src/Behat/behat.yml
 curl -s -L -q https://github.com/deviantintegral/drupal_tests/raw/$TAG/templates/module/tests/src/Behat/example.behat.local.yml > tests/src/Behat/example.behat.local.yml
 curl -s -L -q https://github.com/deviantintegral/drupal_tests/raw/$TAG/templates/module/tests/src/Behat/features/bootstrap/MyModuleFeatureContext.php > tests/src/Behat/features/bootstrap/${MODULE_CC}FeatureContext.php
 
+# Replace placeholders in the Behat configuration.
 perl -i -pe "s/my_module/$MODULE/g" tests/src/Behat/features/bootstrap/${MODULE_CC}FeatureContext.php tests/src/Behat/example.behat.local.yml tests/src/Behat/behat.yml
 perl -i -pe "s/MyModule/$MODULE_CC/g" tests/src/Behat/features/bootstrap/${MODULE_CC}FeatureContext.php tests/src/Behat/example.behat.local.yml tests/src/Behat/behat.yml
 

--- a/setup.sh
+++ b/setup.sh
@@ -47,4 +47,12 @@ then
   echo 'tests/src/Behat/behat.local.yml' >> .gitignore
 fi
 
+composer require --dev --no-update \
+    behat/mink-selenium2-driver \
+    drupal/coder \
+    drupal/drupal-extension \
+    bex/behat-screenshot \
+    phpmd/phpmd \
+    phpmetrics/phpmetrics
+
 echo 'Setup complete. You are now ready to test with CircleCI!'

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,50 @@
+#!/bin/bash -e
+
+MODULE=$(basename $(pwd))
+MODULE_CC=$(echo $MODULE | perl -pe 's/(^|_)(\w)/\U$2/g')
+
+echo "Using $MODULE as the module name and $MODULE_CC as the CamelCase version."
+
+# Get the latest tag. We have to use the v3 API as GraphQL doens't support
+# anonymous access.
+# It is currently sorted in reverse chronological order. To always be correct,
+# we should probably query each tag and then sort, but we want to maintain
+# anonymous support and that could easily hit the API limit.
+if [ -z "$1" ]
+then
+  TAG=$(curl -s https://api.github.com/repos/deviantintegral/drupal_tests/tags | grep name | head -n 1 | awk -F\" '{print $4}')
+else
+  TAG=$1
+fi
+
+echo "Using $TAG as the container version."
+
+# Download the CircleCI configuration.
+mkdir -p .circleci
+curl -s -L https://github.com/deviantintegral/drupal_tests/raw/$TAG/templates/circleci-2.0/config.yml > .circleci/config.yml
+
+# Update the container version in the config file.
+sed -i '' "s/andrewberry\/drupal_tests:latest/andrewberry\/drupal_tests:$TAG/g" .circleci/config.yml
+sed -i '' "s/my_module/$MODULE/g" .circleci/config.yml
+
+# Set up phpunit with code coverage for this module.
+curl -s -L -q -OJ https://github.com/deviantintegral/drupal_tests/raw/$TAG/templates/module/phpunit.core.xml.dist
+sed -i '' "s/my_module/$MODULE/g" phpunit.core.xml.dist
+
+# Download and set up the Behat testing configuration.
+mkdir -p "tests/src/Behat/features/bootstrap"
+
+curl -s -L -q https://github.com/deviantintegral/drupal_tests/raw/$TAG/templates/module/tests/src/Behat/behat.yml > tests/src/Behat/behat.yml
+curl -s -L -q https://github.com/deviantintegral/drupal_tests/raw/$TAG/templates/module/tests/src/Behat/example.behat.local.yml > tests/src/Behat/example.behat.local.yml
+curl -s -L -q https://github.com/deviantintegral/drupal_tests/raw/$TAG/templates/module/tests/src/Behat/features/bootstrap/MyModuleFeatureContext.php > tests/src/Behat/features/bootstrap/${MODULE_CC}FeatureContext.php
+
+sed -i '' "s/my_module/$MODULE/g" tests/src/Behat/features/bootstrap/${MODULE_CC}FeatureContext.php tests/src/Behat/example.behat.local.yml tests/src/Behat/behat.yml
+sed -i '' "s/MyModule/$MODULE_CC/g" tests/src/Behat/features/bootstrap/${MODULE_CC}FeatureContext.php tests/src/Behat/example.behat.local.yml tests/src/Behat/behat.yml
+
+touch .gitignore
+if [ ! $(grep behat.local.yml .gitignore) ]
+then
+  echo 'tests/src/Behat/behat.local.yml' >> .gitignore
+fi
+
+echo 'Setup complete. You are now ready to test with CircleCI!'

--- a/setup.sh
+++ b/setup.sh
@@ -24,12 +24,12 @@ mkdir -p .circleci
 curl -s -L https://github.com/deviantintegral/drupal_tests/raw/$TAG/templates/circleci-2.0/config.yml > .circleci/config.yml
 
 # Update the container version in the config file.
-sed -i '' "s/andrewberry\/drupal_tests:latest/andrewberry\/drupal_tests:$TAG/g" .circleci/config.yml
-sed -i '' "s/my_module/$MODULE/g" .circleci/config.yml
+perl -i -pe "s/andrewberry\/drupal_tests:latest/andrewberry\/drupal_tests:$TAG/g" .circleci/config.yml
+perl -i -pe "s/my_module/$MODULE/g" .circleci/config.yml
 
 # Set up phpunit with code coverage for this module.
 curl -s -L -q -OJ https://github.com/deviantintegral/drupal_tests/raw/$TAG/templates/module/phpunit.core.xml.dist
-sed -i '' "s/my_module/$MODULE/g" phpunit.core.xml.dist
+perl -i -pe "s/my_module/$MODULE/g" phpunit.core.xml.dist
 
 # Download and set up the Behat testing configuration.
 mkdir -p "tests/src/Behat/features/bootstrap"
@@ -38,8 +38,8 @@ curl -s -L -q https://github.com/deviantintegral/drupal_tests/raw/$TAG/templates
 curl -s -L -q https://github.com/deviantintegral/drupal_tests/raw/$TAG/templates/module/tests/src/Behat/example.behat.local.yml > tests/src/Behat/example.behat.local.yml
 curl -s -L -q https://github.com/deviantintegral/drupal_tests/raw/$TAG/templates/module/tests/src/Behat/features/bootstrap/MyModuleFeatureContext.php > tests/src/Behat/features/bootstrap/${MODULE_CC}FeatureContext.php
 
-sed -i '' "s/my_module/$MODULE/g" tests/src/Behat/features/bootstrap/${MODULE_CC}FeatureContext.php tests/src/Behat/example.behat.local.yml tests/src/Behat/behat.yml
-sed -i '' "s/MyModule/$MODULE_CC/g" tests/src/Behat/features/bootstrap/${MODULE_CC}FeatureContext.php tests/src/Behat/example.behat.local.yml tests/src/Behat/behat.yml
+perl -i -pe "s/my_module/$MODULE/g" tests/src/Behat/features/bootstrap/${MODULE_CC}FeatureContext.php tests/src/Behat/example.behat.local.yml tests/src/Behat/behat.yml
+perl -i -pe "s/MyModule/$MODULE_CC/g" tests/src/Behat/features/bootstrap/${MODULE_CC}FeatureContext.php tests/src/Behat/example.behat.local.yml tests/src/Behat/behat.yml
 
 touch .gitignore
 if [ ! $(grep behat.local.yml .gitignore) ]

--- a/templates/circleci-2.0/config.yml
+++ b/templates/circleci-2.0/config.yml
@@ -35,7 +35,7 @@ defaults: &defaults
   # 'checkout' supports a path key, but not on locals where you test with the
   # circleci CLI tool.
   # https://discuss.circleci.com/t/bug-circleci-build-command-ignores-checkout-path-config/13004
-  working_directory: /var/www/html/modules/MODULE_NAME
+  working_directory: /var/www/html/modules/my_module
 
 # YAML does not support merging of lists. That means we can't have a default
 # 'steps' configuration, though we can have defaults for individual step

--- a/templates/circleci-2.0/config.yml
+++ b/templates/circleci-2.0/config.yml
@@ -1,6 +1,7 @@
 # Default configuration file for Drupal modules.
 #
-# To use this in a new module:
+# Use setup.sh to automate setting this up. Otherwise, to use this in a new
+# module:
 #   1. Copy config.yml to the module's .circleci directory.
 #   2. Change 'latest' in the image tag to the latest tag.
 #   3. Update the working_directory key.

--- a/test.sh
+++ b/test.sh
@@ -3,7 +3,7 @@
 # Test first manually specifying a branch
 git init test_this_branch
 cd test_this_branch
-curl -L https://github.com/deviantintegral/drupal_tests/raw/$1/setup.sh test_this_branch | bash
+../setup.sh | bash
 if [ $(egrep -r (my_module|MyModule) * .circleci .gitignore) ]
 then
   exit 1
@@ -13,7 +13,7 @@ cd ..
 # Now test using this code to fetch the last tag
 git init test_last_tag
 cd test_last_tag
-curl -L https://github.com/deviantintegral/drupal_tests/raw/$1/setup.sh | bash
+../setup.sh | bash
 if [ $(egrep -r (my_module|MyModule) * .circleci .gitignore) ]
 then
   exit 1

--- a/test.sh
+++ b/test.sh
@@ -30,17 +30,5 @@ then
   exit 1
 fi
 set -e
-cd ..
-
-# Finally, test using a real module!
-git clone https://github.com/BurdaMagazinOrg/module-fb_instant_articles.git fb_instant_articles
-cd fb_instant_articles
-git checkout 66f934b196d6415f7f2dbad48d57653a7d02ee84
-../setup.sh
-circleci build --job run-unit-kernel-tests
-circleci build --job run-behat-tests
-# We don't run the code coverage job because it's very slow
-circleci build --job run-code-sniffer-tests
-cd ..
 
 echo 'All tests have passed.'

--- a/test.sh
+++ b/test.sh
@@ -3,8 +3,10 @@
 # Test first manually specifying a branch
 git init test_this_branch
 cd test_this_branch
-../setup.sh
-if [ $(egrep -r (my_module|MyModule) * .circleci .gitignore) ]
+../setup.sh $1
+egrep -r '(my_module|MyModule)' * .circleci .gitignore
+CHECK=$?
+if [ $? ]
 then
   exit 1
 fi
@@ -14,7 +16,9 @@ cd ..
 git init test_last_tag
 cd test_last_tag
 ../setup.sh
-if [ $(egrep -r (my_module|MyModule) * .circleci .gitignore) ]
+egrep -r '(my_module|MyModule)' * .circleci .gitignore
+CHECK=$?
+if [ $? ]
 then
   exit 1
 fi

--- a/test.sh
+++ b/test.sh
@@ -3,7 +3,7 @@
 # Test first manually specifying a branch
 git init test_this_branch
 cd test_this_branch
-../setup.sh | bash
+../setup.sh
 if [ $(egrep -r (my_module|MyModule) * .circleci .gitignore) ]
 then
   exit 1
@@ -13,7 +13,7 @@ cd ..
 # Now test using this code to fetch the last tag
 git init test_last_tag
 cd test_last_tag
-../setup.sh | bash
+../setup.sh
 if [ $(egrep -r (my_module|MyModule) * .circleci .gitignore) ]
 then
   exit 1

--- a/test.sh
+++ b/test.sh
@@ -3,7 +3,9 @@
 # Test first manually specifying a branch
 git init test_this_branch
 cd test_this_branch
+composer init -n --name=example/test
 ../setup.sh $1
+circleci config validate
 set +e
 egrep -r '(my_module|MyModule)' * .circleci .gitignore
 CHECK=$?
@@ -17,7 +19,9 @@ cd ..
 # Now test using this code to fetch the last tag
 git init test_last_tag
 cd test_last_tag
+composer init -n --name=example/test
 ../setup.sh
+circleci config validate
 set +e
 egrep -r '(my_module|MyModule)' * .circleci .gitignore
 CHECK=$?

--- a/test.sh
+++ b/test.sh
@@ -4,21 +4,27 @@
 git init test_this_branch
 cd test_this_branch
 ../setup.sh $1
+set +e
 egrep -r '(my_module|MyModule)' * .circleci .gitignore
 CHECK=$?
-if [ $? ]
+if [ ! $? ]
 then
   exit 1
 fi
+set -e
 cd ..
 
 # Now test using this code to fetch the last tag
 git init test_last_tag
 cd test_last_tag
 ../setup.sh
+set +e
 egrep -r '(my_module|MyModule)' * .circleci .gitignore
 CHECK=$?
-if [ $? ]
+if [ ! $? ]
 then
   exit 1
 fi
+set -e
+
+echo 'All tests have passed.'

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,20 @@
+#!/bin/bash -ex
+
+# Test first manually specifying a branch
+git init test_this_branch
+cd test_this_branch
+curl -L https://github.com/deviantintegral/drupal_tests/raw/$1/setup.sh test_this_branch | bash
+if [ $(egrep -r (my_module|MyModule) * .circleci .gitignore) ]
+then
+  exit 1
+fi
+cd ..
+
+# Now test using this code to fetch the last tag
+git init test_last_tag
+cd test_last_tag
+curl -L https://github.com/deviantintegral/drupal_tests/raw/$1/setup.sh | bash
+if [ $(egrep -r (my_module|MyModule) * .circleci .gitignore) ]
+then
+  exit 1
+fi

--- a/test.sh
+++ b/test.sh
@@ -30,5 +30,17 @@ then
   exit 1
 fi
 set -e
+cd ..
+
+# Finally, test using a real module!
+git clone https://github.com/BurdaMagazinOrg/module-fb_instant_articles.git fb_instant_articles
+cd fb_instant_articles
+git checkout 66f934b196d6415f7f2dbad48d57653a7d02ee84
+../setup.sh
+sudo circleci build --job run-unit-kernel-tests
+circleci build --job run-behat-tests
+# We don't run the code coverage job because it's very slow
+circleci build --job run-code-sniffer-tests
+cd ..
 
 echo 'All tests have passed.'

--- a/test.sh
+++ b/test.sh
@@ -37,7 +37,7 @@ git clone https://github.com/BurdaMagazinOrg/module-fb_instant_articles.git fb_i
 cd fb_instant_articles
 git checkout 66f934b196d6415f7f2dbad48d57653a7d02ee84
 ../setup.sh
-sudo circleci build --job run-unit-kernel-tests
+circleci build --job run-unit-kernel-tests
 circleci build --job run-behat-tests
 # We don't run the code coverage job because it's very slow
 circleci build --job run-code-sniffer-tests

--- a/test.sh
+++ b/test.sh
@@ -7,7 +7,7 @@ cd test_this_branch
 set +e
 egrep -r '(my_module|MyModule)' * .circleci .gitignore
 CHECK=$?
-if [ ! $? ]
+if [ $CHECK -eq 0 ]
 then
   exit 1
 fi
@@ -21,7 +21,7 @@ cd test_last_tag
 set +e
 egrep -r '(my_module|MyModule)' * .circleci .gitignore
 CHECK=$?
-if [ ! $? ]
+if [ $CHECK -eq 0 ]
 then
   exit 1
 fi


### PR DESCRIPTION
See the README for how this works. Also, I added basic circle jobs testing the setup scripts themselves.

```bash
curl -L https://github.com/deviantintegral/drupal_tests/raw/b97f3dfb6a027a88eea2cc13b9a9847e18638657/setup.sh | bash
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   178  100   178    0     0    610      0 --:--:-- --:--:-- --:--:--   611
100  2487  100  2487    0     0   5198      0 --:--:-- --:--:-- --:--:--  5198
Using entity_destroyer as the module name and EntityDestroyer as the CamelCase version.
Using 0.0.9 as the container version.
Setup complete. You are now ready to test with CircleCI!
```