### PR TITLE
Specify the version of drupal-extension

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -50,7 +50,7 @@ fi
 composer require --dev --no-update \
     behat/mink-selenium2-driver \
     drupal/coder \
-    drupal/drupal-extension \
+    drupal/drupal-extension:master-dev \
     bex/behat-screenshot \
     phpmd/phpmd \
     phpmetrics/phpmetrics


### PR DESCRIPTION
Otherwise composer install will fail due to different constraints because Robo attempts to add `master-dev`.

Perhaps we could remove the composer require statement alltogether since Robo does it already?