### PR TITLE
Mark code coverage as needing unit tests to complete first.

### DIFF
--- a/templates/circleci-2.0/config.yml
+++ b/templates/circleci-2.0/config.yml
@@ -152,3 +152,6 @@ workflows:
       - run-behat-tests
       - run-code-sniffer
       - run-code-coverage
+      - run-code-coverage:
+          requires:
+            - run-unit-kernel-tests

--- a/templates/circleci-2.0/config.yml
+++ b/templates/circleci-2.0/config.yml
@@ -151,7 +151,6 @@ workflows:
       - run-unit-kernel-tests
       - run-behat-tests
       - run-code-sniffer
-      - run-code-coverage
       - run-code-coverage:
           requires:
             - run-unit-kernel-tests


### PR DESCRIPTION
Because the code coverage also run tests much more slowly than the normal run test job, it seems wise to delay running this job until the test job successfully completes. This should help slightly increase the capacity of parallel job running.