### PR TITLE
Fix missing composer-patches requirement

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -48,6 +48,7 @@ then
 fi
 
 composer require --dev --no-update \
+    cweagans/composer-patches \
     behat/mink-selenium2-driver \
     drupal/coder \
     drupal/drupal-extension:master-dev \


### PR DESCRIPTION
I think this should be automatic so `patches.json` works as documented without an additional composer command.