### PR TITLE
Fix not respecting manually set setup versions

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -68,4 +68,4 @@ drupal_tests_install() {
   echo 'Setup complete. You are now ready to test with CircleCI!'
 }
 
-drupal_tests_install
+drupal_tests_install $1

--- a/test.sh
+++ b/test.sh
@@ -4,7 +4,8 @@
 git init test_this_branch
 cd test_this_branch
 composer init -n --name=example/test
-../setup.sh $1
+SETUP=$(../setup.sh $1)
+echo $SETUP | grep "$1"
 circleci config validate
 set +e
 egrep -r '(my_module|MyModule)' * .circleci .gitignore


### PR DESCRIPTION
This fixes trying to setup with a specific tag or branch, instead of the latest tag.