### PR TITLE
Create a root job for composer update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
+* A single job is now used to initialize composer, and it's results are used to
+  seed all of the individual test jobs.
+  [#26](https://github.com/deviantintegral/drupal_tests/pull/26/files)
+
 ### Changed
 
 ### Fixed

--- a/hooks/code-coverage-stats.sh
+++ b/hooks/code-coverage-stats.sh
@@ -4,6 +4,11 @@ export SIMPLETEST_BASE_URL="http://localhost"
 export SIMPLETEST_DB="sqlite://localhost//tmp/drupal.sqlite"
 export BROWSERTEST_OUTPUT_DIRECTORY="/var/www/html/sites/simpletest"
 
+if [ ! -f dependencies_updated ]
+then
+  ./update-dependencies.sh $1
+fi
+
 robo override:phpunit-config $1
 
 timeout 60m sudo -E -u www-data robo test:coverage $1 artifacts || true

--- a/hooks/code-coverage-stats.sh
+++ b/hooks/code-coverage-stats.sh
@@ -4,12 +4,6 @@ export SIMPLETEST_BASE_URL="http://localhost"
 export SIMPLETEST_DB="sqlite://localhost//tmp/drupal.sqlite"
 export BROWSERTEST_OUTPUT_DIRECTORY="/var/www/html/sites/simpletest"
 
-robo setup:skeleton
-
-robo add:modules $1
-
-robo update:dependencies
-
 robo override:phpunit-config $1
 
 timeout 60m sudo -E -u www-data robo test:coverage $1 artifacts || true

--- a/hooks/code-sniffer.sh
+++ b/hooks/code-sniffer.sh
@@ -2,14 +2,6 @@
 
 # Runs CodeSniffer checks on a Drupal module.
 
-robo setup:skeleton
-
-robo add:coding-standards-deps
-
-robo add:modules $1
-
-robo update:dependencies
-
 # Install dependencies and configure phpcs
 vendor/bin/phpcs --config-set installed_paths vendor/drupal/coder/coder_sniffer
 

--- a/hooks/code-sniffer.sh
+++ b/hooks/code-sniffer.sh
@@ -2,6 +2,11 @@
 
 # Runs CodeSniffer checks on a Drupal module.
 
+if [ ! -f dependencies_updated ]
+then
+  ./update-dependencies.sh $1
+fi
+
 # Install dependencies and configure phpcs
 vendor/bin/phpcs --config-set installed_paths vendor/drupal/coder/coder_sniffer
 

--- a/hooks/test-js.sh
+++ b/hooks/test-js.sh
@@ -7,10 +7,6 @@
 # This is the command used by the base image to serve Drupal.
 apache2-foreground&
 
-robo add:behat-deps
-
-robo add:modules $1
-
 robo update:dependencies
 
 robo setup:drupal || true

--- a/hooks/test-js.sh
+++ b/hooks/test-js.sh
@@ -13,7 +13,7 @@ fi
 apache2-foreground&
 
 # Wait for the mariadb container to come up.
-while ! mysqladmin ping -h127.0.0.1; do sleep 1; done
+while ! mysqladmin ping --silent -h127.0.0.1; do sleep 1; done
 
 robo setup:drupal || true
 

--- a/hooks/test-js.sh
+++ b/hooks/test-js.sh
@@ -4,6 +4,11 @@
 #
 # Runs Behat tests.
 
+if [ ! -f dependencies_updated ]
+then
+  ./update-dependencies.sh $1
+fi
+
 # This is the command used by the base image to serve Drupal.
 apache2-foreground&
 

--- a/hooks/test-js.sh
+++ b/hooks/test-js.sh
@@ -7,8 +7,6 @@
 # This is the command used by the base image to serve Drupal.
 apache2-foreground&
 
-robo update:dependencies
-
 robo setup:drupal || true
 
 chown -R www-data:www-data /var/www/html/sites/default/files

--- a/hooks/test-js.sh
+++ b/hooks/test-js.sh
@@ -12,6 +12,9 @@ fi
 # This is the command used by the base image to serve Drupal.
 apache2-foreground&
 
+# Wait for the mariadb container to come up.
+while ! mysqladmin ping -h127.0.0.1; do sleep 1; done
+
 robo setup:drupal || true
 
 chown -R www-data:www-data /var/www/html/sites/default/files

--- a/hooks/test.sh
+++ b/hooks/test.sh
@@ -9,11 +9,6 @@ export BROWSERTEST_OUTPUT_DIRECTORY="/var/www/html/sites/simpletest"
 # This is the command used by the base image to serve Drupal.
 apache2-foreground&
 
-robo setup:skeleton
-robo add:modules $1
-
-robo update:dependencies
-
 robo override:phpunit-config $1
 
 sudo -E -u www-data vendor/bin/phpunit -c core --group $1 --debug --verbose --log-junit artifacts/phpunit/phpunit.xml

--- a/hooks/test.sh
+++ b/hooks/test.sh
@@ -6,6 +6,11 @@ export SIMPLETEST_BASE_URL="http://localhost"
 export SIMPLETEST_DB="sqlite://localhost//tmp/drupal.sqlite"
 export BROWSERTEST_OUTPUT_DIRECTORY="/var/www/html/sites/simpletest"
 
+if [ ! -f dependencies_updated ]
+then
+  ./update-dependencies.sh $1
+fi
+
 # This is the command used by the base image to serve Drupal.
 apache2-foreground&
 

--- a/hooks/update-dependencies.sh
+++ b/hooks/update-dependencies.sh
@@ -3,5 +3,6 @@
 robo setup:skeleton
 robo add:modules $1
 
-robo update:dependencies
 robo add:behat-deps
+robo add:coding-standards-deps
+robo update:dependencies

--- a/hooks/update-dependencies.sh
+++ b/hooks/update-dependencies.sh
@@ -10,4 +10,4 @@ robo update:dependencies
 # Touch a flag so we know dependencies have been set. Otherwise, there is no
 # easy way to know this step needs to be done when running circleci locally since
 # it does not support workflows.
-touch dependencies-updated
+touch dependencies_updated

--- a/hooks/update-dependencies.sh
+++ b/hooks/update-dependencies.sh
@@ -2,9 +2,6 @@
 
 robo setup:skeleton
 robo add:modules $1
-
-robo add:behat-deps
-robo add:coding-standards-deps
 robo update:dependencies
 
 # Touch a flag so we know dependencies have been set. Otherwise, there is no

--- a/hooks/update-dependencies.sh
+++ b/hooks/update-dependencies.sh
@@ -1,0 +1,7 @@
+#!/bin/bash -ex
+
+robo setup:skeleton
+robo add:modules $1
+
+robo update:dependencies
+robo add:behat-deps

--- a/hooks/update-dependencies.sh
+++ b/hooks/update-dependencies.sh
@@ -6,3 +6,8 @@ robo add:modules $1
 robo add:behat-deps
 robo add:coding-standards-deps
 robo update:dependencies
+
+# Touch a flag so we know dependencies have been set. Otherwise, there is no
+# easy way to know this step needs to be done when running circleci locally since
+# it does not support workflows.
+touch dependencies-updated

--- a/templates/circleci-2.0/config.yml
+++ b/templates/circleci-2.0/config.yml
@@ -70,7 +70,7 @@ update_dependencies: &update_dependencies
           ./update-dependencies.sh $CIRCLE_PROJECT_REPONAME
 
     - persist_to_workspace:
-        root: workspace
+        root: /var/www/html
         paths:
           - .
 
@@ -80,7 +80,7 @@ unit_kernel_tests: &unit_kernel_tests
   <<: *defaults
   steps:
     - attach_workspace:
-        at: .
+        at: /var/www/html
 
     - checkout
 
@@ -102,7 +102,7 @@ behat_tests: &behat_tests
   <<: *defaults
   steps:
     - attach_workspace:
-        at: .
+        at: /var/www/html
 
     - checkout
 
@@ -124,7 +124,7 @@ code_sniffer: &code_sniffer
   <<: *defaults
   steps:
     - attach_workspace:
-        at: .
+        at: /var/www/html
 
     - checkout
 
@@ -146,7 +146,7 @@ code_coverage: &code_coverage
   <<: *defaults
   steps:
     - attach_workspace:
-        at: .
+        at: /var/www/html
 
     - checkout
 
@@ -156,13 +156,15 @@ code_coverage: &code_coverage
     - run:
         working_directory: /var/www/html
         command: |
-          ./code-coverage-stats.sh $CIRCLE_PROJECT_REPONAME
+          ./code-coverage-stats.sh node
     - store_artifacts:
         path: /var/www/html/artifacts
 
 # Declare all of the jobs we should run.
 version: 2
 jobs:
+  update-dependencies:
+     <<: *update_dependencies
   run-unit-kernel-tests:
      <<: *unit_kernel_tests
   run-behat-tests:

--- a/templates/circleci-2.0/config.yml
+++ b/templates/circleci-2.0/config.yml
@@ -44,16 +44,16 @@ defaults: &defaults
 # We use the composer.json as a way to determine if we can cache our build.
 restore_cache: &restore_cache
   keys:
-  - v2-dependencies-{{ checksum "composer.json" }}-{{ checksum "../../composer.json" }}
+  - v3-dependencies-{{ checksum "composer.json" }}-{{ checksum "../../composer.json" }}
   # fallback to using the latest cache if no exact match is found
-  - v2-dependencies-
+  - v3-dependencies-
 
 # If composer.json hasn't changed, restore the vendor directory. We don't
 # restore the lock file so we ensure we get updated dependencies.
 save_cache: &save_cache
   paths:
     - ../../vendor
-  key: v2-dependencies-{{ checksum "composer.json" }}-{{ checksum "../../composer.json" }}
+  key: v3-dependencies-{{ checksum "composer.json" }}-{{ checksum "../../composer.json" }}
 
 # Install composer dependencies into the workspace to share with all jobs.
 update_dependencies: &update_dependencies

--- a/templates/circleci-2.0/config.yml
+++ b/templates/circleci-2.0/config.yml
@@ -145,7 +145,7 @@ code_coverage: &code_coverage
     - run:
         working_directory: /var/www/html
         command: |
-          ./code-coverage-stats.sh node
+          ./code-coverage-stats.sh $CIRCLE_PROJECT_REPONAME
     - store_artifacts:
         path: /var/www/html/artifacts
 

--- a/templates/circleci-2.0/config.yml
+++ b/templates/circleci-2.0/config.yml
@@ -62,12 +62,13 @@ update_dependencies: &update_dependencies
     - checkout
 
     - restore_cache: *restore_cache
-    - save_cache: *save_cache
 
     - run:
         working_directory: /var/www/html
         command: |
           ./update-dependencies.sh $CIRCLE_PROJECT_REPONAME
+
+    - save_cache: *save_cache
 
     - persist_to_workspace:
         root: /var/www/html
@@ -83,9 +84,6 @@ unit_kernel_tests: &unit_kernel_tests
         at: /var/www/html
 
     - checkout
-
-    - restore_cache: *restore_cache
-    - save_cache: *save_cache
 
     - run:
         working_directory: /var/www/html
@@ -106,9 +104,6 @@ behat_tests: &behat_tests
 
     - checkout
 
-    - restore_cache: *restore_cache
-    - save_cache: *save_cache
-
     - run:
         working_directory: /var/www/html
         command: |
@@ -128,9 +123,6 @@ code_sniffer: &code_sniffer
 
     - checkout
 
-    - restore_cache: *restore_cache
-    - save_cache: *save_cache
-
     - run:
         working_directory: /var/www/html
         command: |
@@ -149,9 +141,6 @@ code_coverage: &code_coverage
         at: /var/www/html
 
     - checkout
-
-    - restore_cache: *restore_cache
-    - save_cache: *save_cache
 
     - run:
         working_directory: /var/www/html

--- a/templates/circleci-2.0/config.yml
+++ b/templates/circleci-2.0/config.yml
@@ -55,11 +55,33 @@ save_cache: &save_cache
     - ./vendor
   key: v1-dependencies-{{ checksum "composer.json" }}
 
+# Install composer dependencies into the workspace to share with all jobs.
+update_dependencies: &update_dependencies
+  <<: *defaults
+  steps:
+    - checkout
+
+    - restore_cache: *restore_cache
+    - save_cache: *save_cache
+
+    - run:
+        working_directory: /var/www/html
+        command: |
+          ./update-dependencies.sh $CIRCLE_PROJECT_REPONAME
+
+    - persist_to_workspace:
+        root: workspace
+        paths:
+          - .
+
 # Run Drupal unit and kernel tests as one job. This command invokes the test.sh
 # hook.
 unit_kernel_tests: &unit_kernel_tests
   <<: *defaults
   steps:
+    - attach_workspace:
+        at: .
+
     - checkout
 
     - restore_cache: *restore_cache
@@ -79,6 +101,9 @@ unit_kernel_tests: &unit_kernel_tests
 behat_tests: &behat_tests
   <<: *defaults
   steps:
+    - attach_workspace:
+        at: .
+
     - checkout
 
     - restore_cache: *restore_cache
@@ -98,6 +123,9 @@ behat_tests: &behat_tests
 code_sniffer: &code_sniffer
   <<: *defaults
   steps:
+    - attach_workspace:
+        at: .
+
     - checkout
 
     - restore_cache: *restore_cache
@@ -117,6 +145,9 @@ code_sniffer: &code_sniffer
 code_coverage: &code_coverage
   <<: *defaults
   steps:
+    - attach_workspace:
+        at: .
+
     - checkout
 
     - restore_cache: *restore_cache
@@ -147,9 +178,16 @@ workflows:
   # Declare a workflow that runs all of our jobs in parallel.
   test_and_lint:
     jobs:
-      - run-unit-kernel-tests
-      - run-behat-tests
-      - run-code-sniffer
+      - run-unit-kernel-tests:
+          requires:
+            - update-dependencies
+      - run-behat-tests:
+          requires:
+            - update-dependencies
+      - run-code-sniffer:
+          requires:
+            - update-dependencies
       - run-code-coverage:
           requires:
+            - update-dependencies
             - run-unit-kernel-tests

--- a/templates/circleci-2.0/config.yml
+++ b/templates/circleci-2.0/config.yml
@@ -44,16 +44,16 @@ defaults: &defaults
 # We use the composer.json as a way to determine if we can cache our build.
 restore_cache: &restore_cache
   keys:
-  - v1-dependencies-{{ checksum "composer.json" }}
+  - v2-dependencies-{{ checksum "composer.json" }}-{{ checksum "../../composer.json" }}
   # fallback to using the latest cache if no exact match is found
-  - v1-dependencies-
+  - v2-dependencies-
 
 # If composer.json hasn't changed, restore the vendor directory. We don't
 # restore the lock file so we ensure we get updated dependencies.
 save_cache: &save_cache
   paths:
-    - ./vendor
-  key: v1-dependencies-{{ checksum "composer.json" }}
+    - ../../vendor
+  key: v2-dependencies-{{ checksum "composer.json" }}-{{ checksum "../../composer.json" }}
 
 # Install composer dependencies into the workspace to share with all jobs.
 update_dependencies: &update_dependencies

--- a/templates/circleci-2.0/config.yml
+++ b/templates/circleci-2.0/config.yml
@@ -178,6 +178,7 @@ workflows:
   # Declare a workflow that runs all of our jobs in parallel.
   test_and_lint:
     jobs:
+      - update-dependencies
       - run-unit-kernel-tests:
           requires:
             - update-dependencies


### PR DESCRIPTION
This doesn't reduce the total time to run jobs, but does reduce CI costs as we only run a single job for the initial `composer update` step.