### PR TITLE
Test actual CI jobs with the circleci tool

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,29 @@
 version: 2
 jobs:
   build:
-    docker:
-      - image: circleci/php:7.1-cli
+    machine:
+      image: circleci/classic:201711-01
+
+    steps:
+      - checkout
+
+      - run:
+          name: Run tests
+          command: ./test.sh
+
+      - run:
+          name: Move artifacts
+          command: |
+            mkdir artifacts
+            mv node artifacts
+
+      - store_artifacts:
+          path: artifacts
+
+  build_with_branch:
+    machine:
+      image: circleci/classic:201711-01
+
     steps:
       - checkout
 
@@ -14,7 +35,15 @@ jobs:
           name: Move artifacts
           command: |
             mkdir artifacts
-            mv test_this_branch test_last_tag artifacts
+            mv node artifacts
 
       - store_artifacts:
           path: artifacts
+
+workflows:
+  version: 2
+  test_both_versions:
+    jobs:
+      # This tests both ./setup.sh and ./setup.sh <branch>
+      - build
+      - build_with_branch

--- a/test.sh
+++ b/test.sh
@@ -1,34 +1,51 @@
 #!/bin/bash -ex
 
-# Test first manually specifying a branch
-git init test_this_branch
-cd test_this_branch
-composer init -n --name=example/test
-../setup.sh $1
-circleci config validate
-set +e
-egrep -r '(my_module|MyModule)' * .circleci .gitignore
-CHECK=$?
-if [ $CHECK -eq 0 ]
-then
-  exit 1
-fi
-set -e
-cd ..
+test_ci() {
+  ../setup.sh $1
 
-# Now test using this code to fetch the last tag
-git init test_last_tag
-cd test_last_tag
-composer init -n --name=example/test
-../setup.sh
-circleci config validate
-set +e
-egrep -r '(my_module|MyModule)' * .circleci .gitignore
-CHECK=$?
-if [ $CHECK -eq 0 ]
+  circleci config validate
+  set +e
+  egrep -r '(my_module|MyModule)' * .circleci .gitignore
+  CHECK=$?
+  if [ $CHECK -eq 0 ]
+  then
+    set -e
+    exit 1
+  fi
+  set -e
+
+  # This module fails CS jobs currently so this is more informational.
+  circleci.sh -e CIRCLE_PROJECT_REPONAME=node build --job run-code-sniffer || true
+  circleci.sh -e CIRCLE_PROJECT_REPONAME=node build --job run-unit-kernel-tests
+
+  circleci.sh -e CIRCLE_PROJECT_REPONAME=node build --job run-behat-tests | tee behat.log
+  # We need to skip colour codes
+  egrep "1 scenario \\(.*1 passed" behat.log
+}
+
+sudo apt-get update -y
+sudo apt-get install php5-cli -y
+EXPECTED_SIGNATURE=$(wget -q -O - https://composer.github.io/installer.sig)
+php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
+ACTUAL_SIGNATURE=$(php -r "echo hash_file('SHA384', 'composer-setup.php');")
+
+if [ "$EXPECTED_SIGNATURE" != "$ACTUAL_SIGNATURE" ]
 then
-  exit 1
+    >&2 echo 'ERROR: Invalid installer signature'
+    rm composer-setup.php
+    exit 1
 fi
-set -e
+
+sudo php composer-setup.php --quiet --install-dir=/usr/local/bin --filename=composer
+
+# There is a circleci CLI tool in the machine image, but it throws errors about
+# missing files when running builds.
+sudo curl -o /usr/local/bin/circleci.sh https://circle-downloads.s3.amazonaws.com/releases/build_agent_wrapper/circleci && sudo chmod +x /usr/local/bin/circleci.sh
+
+git clone git@github.com:deviantintegral/drupal_tests_node_example.git node
+cd node
+git checkout 118b911
+
+test_ci $1
 
 echo 'All tests have passed.'


### PR DESCRIPTION
This PR uses the full-VM version of CircleCI so we can have full control over Docker. Now, instead of just testing some basics of our setup script, we can actually clone a module and run it's tests.