### PR TITLE
Use a local container for test builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,6 +4,9 @@ jobs:
     machine:
       image: circleci/classic:201711-01
 
+    environment:
+      - CI_SYSTEM: circleci
+
     steps:
       - checkout
 
@@ -23,6 +26,9 @@ jobs:
   build_with_branch:
     machine:
       image: circleci/classic:201711-01
+
+    environment:
+      - CI_SYSTEM: circleci
 
     steps:
       - checkout

--- a/setup.sh
+++ b/setup.sh
@@ -25,14 +25,21 @@ drupal_tests_install() {
     TAG=$1
   fi
 
-  echo "Using $TAG as the container version."
+  DOCKER_TAG="andrewberry\/drupal_tests:$TAG"
+  if [ ! -z "$1" ] && [ ! -z "$CI_SYSTEM" ]
+  then
+    DOCKER_TAG=$CI_SYSTEM-build
+  fi
+
+  echo "Using $TAG as the config version."
+  echo "Using $DOCKER_TAG as the container version."
 
   # Download the CircleCI configuration.
   mkdir -p .circleci
   curl -s -L https://github.com/deviantintegral/drupal_tests/raw/$TAG/templates/circleci-2.0/config.yml > .circleci/config.yml
 
   # Update the container version in the config file.
-  perl -i -pe "s/andrewberry\/drupal_tests:latest/andrewberry\/drupal_tests:$TAG/g" .circleci/config.yml
+  perl -i -pe "s/andrewberry\/drupal_tests:latest/$DOCKER_TAG/g" .circleci/config.yml
   perl -i -pe "s/my_module/$MODULE/g" .circleci/config.yml
 
   # Set up phpunit with code coverage for this module.

--- a/test.sh
+++ b/test.sh
@@ -43,6 +43,13 @@ sudo php composer-setup.php --quiet --install-dir=/usr/local/bin --filename=comp
 # missing files when running builds.
 sudo curl -o /usr/local/bin/circleci.sh https://circle-downloads.s3.amazonaws.com/releases/build_agent_wrapper/circleci && sudo chmod +x /usr/local/bin/circleci.sh
 
+# Docker Hub can take 20 minutes to build and sometimes fails. Instead, we
+# test against a locally built copy of the image when building this branch.
+if [ ! -z $1 ]
+then
+  docker build -t $CI_SYSTEM-build .
+fi
+
 git clone git@github.com:deviantintegral/drupal_tests_node_example.git node
 cd node
 git checkout 118b911


### PR DESCRIPTION
The [last merge to master failed](https://circleci.com/gh/deviantintegral/drupal_tests/100).

This was because we tried to fetch a "master" container version from Docker Hub, when in Docker it's called "latest". In working on this, I realized that there's also a race condition exposed. If a branch is pushed for the first time, it may take a long time for Docker Hub to build (I've seen 20+ minutes and many random failed builds). Of course, a PR may depend on those Dockerfile changes.

This PR builds the current branch locally and uses that container image instead. Otherwise, for testing "latest tag" we still go out to Docker Hub.