### PR TITLE
Allow master when setting up projects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+* `setup.sh` now allows `master` to be used, properly mapping it to the
+  `latest` Docker container build.
+
 ## [0.2.0] - 2018-01-09
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ Be sure to review for any customizations you may want to preserve. For example:
 
 ```sh
 $ git checkout -b update-circleci
-$ curl -L https://github.com/deviantintegral/drupal_tests/raw/master/setup.sh | bash
+$ bash -c "$(curl -fsSL https://github.com/deviantintegral/drupal_tests/raw/master/setup.sh)"
 $ git add -p # Add all changes you want to make.
 $ git checkout -p # Remove any changes you don't want to make.
 $ git status # Check for any newly added files.

--- a/setup.sh
+++ b/setup.sh
@@ -29,6 +29,9 @@ drupal_tests_install() {
   if [ ! -z "$1" ] && [ ! -z "$CI_SYSTEM" ]
   then
     DOCKER_TAG=$CI_SYSTEM-build
+  elif [ "$1" == "master" ]
+  then
+    DOCKER_TAG="andrewberry\/drupal_tests:latest"
   fi
 
   echo "Using $TAG as the config version."


### PR DESCRIPTION
This allows master to be used when running `setup.sh`.