### PR TITLE
Only store the files cache, not /vendor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased] - YYYY-MM-DD
+
+### Fixed
+
+* It turns out that caching `vendor` based only on `composer.json` is a very
+  bad idea. Instead, only cache the literal Composer cache. #35
+
 ## [0.3.1] - 2018-02-23
 
 ### Fixed

--- a/templates/circleci-2.0/config.yml
+++ b/templates/circleci-2.0/config.yml
@@ -48,8 +48,8 @@ restore_cache: &restore_cache
   # fallback to using the latest cache if no exact match is found
   - v3-dependencies-
 
-# If composer.json hasn't changed, restore the vendor directory. We don't
-# restore the lock file so we ensure we get updated dependencies.
+# If composer.json hasn't changed, restore the Composer cache directory. We
+# don't restore the lock file so we ensure we get updated dependencies.
 save_cache: &save_cache
   paths:
     - /root/.composer/cache/files

--- a/templates/circleci-2.0/config.yml
+++ b/templates/circleci-2.0/config.yml
@@ -52,7 +52,7 @@ restore_cache: &restore_cache
 # restore the lock file so we ensure we get updated dependencies.
 save_cache: &save_cache
   paths:
-    - ../../vendor
+    - /root/.composer/cache/files
   key: v3-dependencies-{{ checksum "composer.json" }}-{{ checksum "../../composer.json" }}
 
 # Install composer dependencies into the workspace to share with all jobs.


### PR DESCRIPTION
See https://github.com/travis-ci/travis-ci/issues/4579#issuecomment-127972205 where it's noted by one of the Composer maintainers that `vendor` is not cache-safe.