### PR TITLE
Increment the cache key version prefix to avoid issues with stale caches.

### DIFF
--- a/templates/circleci-2.0/config.yml
+++ b/templates/circleci-2.0/config.yml
@@ -44,16 +44,16 @@ defaults: &defaults
 # We use the composer.json as a way to determine if we can cache our build.
 restore_cache: &restore_cache
   keys:
-  - v3-dependencies-{{ checksum "composer.json" }}-{{ checksum "../../composer.json" }}
+  - v4-dependencies-{{ checksum "composer.json" }}-{{ checksum "../../composer.json" }}
   # fallback to using the latest cache if no exact match is found
-  - v3-dependencies-
+  - v4-dependencies-
 
 # If composer.json hasn't changed, restore the Composer cache directory. We
 # don't restore the lock file so we ensure we get updated dependencies.
 save_cache: &save_cache
   paths:
     - /root/.composer/cache/files
-  key: v3-dependencies-{{ checksum "composer.json" }}-{{ checksum "../../composer.json" }}
+  key: v4-dependencies-{{ checksum "composer.json" }}-{{ checksum "../../composer.json" }}
 
 # Install composer dependencies into the workspace to share with all jobs.
 update_dependencies: &update_dependencies


### PR DESCRIPTION
I found then when updating a repo already using drupal_tests CircleCI templates, I needed to increment the cache key so that it would avoid using old, stale, broken caches.