### PR TITLE
Fix patches

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,6 +41,7 @@ RUN composer global require hirak/prestissimo
 RUN cd /var/www/html \
   && cp composer.json composer.json.original \
   && cp composer.lock composer.lock.original \
+  && mv vendor vendor.original \
   && composer require --dev \
       cweagans/composer-patches \
       behat/mink-selenium2-driver \
@@ -50,9 +51,10 @@ RUN cd /var/www/html \
       bex/behat-screenshot \
       phpmd/phpmd \
       phpmetrics/phpmetrics \
+  && rm -rf vendor \
   && mv composer.json.original composer.json \
   && mv composer.lock.original composer.lock \
-  && COMPOSER_DISCARD_CHANGES=1 composer install
+  && mv vendor.original vendor
 
 COPY hooks/* /var/www/html/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,7 +44,7 @@ RUN cd /var/www/html \
   && mv vendor vendor.original \
   && composer require --dev \
       cweagans/composer-patches \
-      behat/mink-selenium2-driver \
+      behat/mink-selenium2-driver:1.3.x-dev \
       behat/mink-extension:v2.2 \
       drupal/coder \
       drupal/drupal-extension:master-dev \

--- a/setup.sh
+++ b/setup.sh
@@ -68,7 +68,7 @@ drupal_tests_install() {
   # If this is updated remember to update the Dockerfile too.
   composer require --dev --no-update \
       cweagans/composer-patches \
-      behat/mink-selenium2-driver \
+      behat/mink-selenium2-driver:1.3.x-dev \
       behat/mink-extension:v2.2 \
       drupal/coder \
       drupal/drupal-extension:master-dev \

--- a/test.sh
+++ b/test.sh
@@ -64,7 +64,7 @@ fi
 
 git clone git@github.com:deviantintegral/drupal_tests_node_example.git node
 cd node
-git checkout 118b911
+git checkout f1fe4f14840db1f904bf0d41e2d22c0c0b72ef6d
 
 test_ci $1
 


### PR DESCRIPTION
Patches are not properly applying. Even though composer-patches is being installed, it's hooks are not being called until a second `composer update` run command, which won't work in CI.

It looks like this is caused by the vendor directory caching optimizations. This PR instead preserves the exact set of vendor / composer files, simply keeping a copy of the files in `/root/.composer/cache` without trying to do anything with the vendor directory.