### PR TITLE
Update mink-selenium2-driver to valid version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -122,7 +122,7 @@ RUN cd /var/www/html \
   && mv vendor vendor.original \
   && composer require --update-with-all-dependencies --dev \
       cweagans/composer-patches \
-      behat/mink-selenium2-driver:1.4.x-dev \
+      "behat/mink-selenium2-driver:1.4.x-dev as 1.3.x-dev" \
       behat/mink-extension:v2.2 \
       drupal/coder:8.2.* \
       drupal/drupal-extension:master-dev \

--- a/Dockerfile
+++ b/Dockerfile
@@ -122,7 +122,7 @@ RUN cd /var/www/html \
   && mv vendor vendor.original \
   && composer require --update-with-all-dependencies --dev \
       cweagans/composer-patches \
-      behat/mink-selenium2-driver:1.3.x-dev \
+      behat/mink-selenium2-driver:1.4.x-dev \
       behat/mink-extension:v2.2 \
       drupal/coder:8.2.* \
       drupal/drupal-extension:master-dev \

--- a/setup.sh
+++ b/setup.sh
@@ -68,7 +68,7 @@ drupal_tests_install() {
   # If this is updated remember to update the Dockerfile too.
   composer require --dev --no-update \
       cweagans/composer-patches \
-      behat/mink-selenium2-driver:1.4.x-dev \
+      "behat/mink-selenium2-driver:1.4.x-dev as 1.3.x-dev" \
       behat/mink-extension:v2.2 \
       drupal/coder \
       drupal/drupal-extension:master-dev \

--- a/setup.sh
+++ b/setup.sh
@@ -68,7 +68,7 @@ drupal_tests_install() {
   # If this is updated remember to update the Dockerfile too.
   composer require --dev --no-update \
       cweagans/composer-patches \
-      behat/mink-selenium2-driver:1.3.x-dev \
+      behat/mink-selenium2-driver:1.4.x-dev \
       behat/mink-extension:v2.2 \
       drupal/coder \
       drupal/drupal-extension:master-dev \


### PR DESCRIPTION
References:
https://www.drupal.org/project/drupal/issues/3078671
https://github.com/minkphp/MinkSelenium2Driver/issues/313
https://github.com/drupal-composer/drupal-project/issues/511
https://github.com/webflo/drupal-core-require-dev/issues/14

Alternatively we hope that this is fixed upstream today with a new 1.3.x version provided by MinkSelenium2Driver that would fulfill the requirements.